### PR TITLE
Non-functional refactoring of the codebase

### DIFF
--- a/example/picow_http_example.cpp
+++ b/example/picow_http_example.cpp
@@ -25,7 +25,7 @@ int main() {
         printf("Connected.\n");
     }
 
-    http::HttpServer server(3036);
+    http::Server server(3036);
 
     server.onGet("/", [](const auto& request, auto& response) {
         response.addHeader("Content-Type", "text/html; charset=utf-8");

--- a/include/http1_1_parser.h
+++ b/include/http1_1_parser.h
@@ -5,14 +5,14 @@
 
 namespace http {
 
-class HttpRequest;
+class Request;
 class HttpResponse;
 
 namespace __internal {
 
 class Http11Parser {
 public:
-    http::HttpRequest fromRequest(const std::string& request) const;
+    http::Request fromRequest(const std::string& request) const;
     std::string toResponse(const http::HttpResponse& response, const std::string& body) const;
 };
 

--- a/include/http1_1_parser.h
+++ b/include/http1_1_parser.h
@@ -6,14 +6,14 @@
 namespace http {
 
 class Request;
-class HttpResponse;
+class Response;
 
 namespace __internal {
 
 class Http11Parser {
 public:
     http::Request fromRequest(const std::string& request) const;
-    std::string toResponse(const http::HttpResponse& response, const std::string& body) const;
+    std::string toResponse(const http::Response& response, const std::string& body) const;
 };
 
 } // namespace __internal

--- a/include/http1_1_parser.h
+++ b/include/http1_1_parser.h
@@ -8,9 +8,7 @@ namespace http {
 class HttpRequest;
 class HttpResponse;
 
-} // namespace http
-
-namespace __http_internal {
+namespace __internal {
 
 class Http11Parser {
 public:
@@ -18,6 +16,8 @@ public:
     std::string toResponse(const http::HttpResponse& response, const std::string& body) const;
 };
 
-} // namespace __http_internal
+} // namespace __internal
+
+} // namespace http
 
 #endif // __HTTP1_1_PARSER_H__

--- a/include/http_headers.h
+++ b/include/http_headers.h
@@ -13,9 +13,7 @@ public:
     HttpHeaders() = default;
 
     HttpHeaders(const HttpHeaders& that): _headers() {
-        if (this != &that) {
-            this->_headers = that._headers;
-        }
+        this->_headers = that._headers;
     }
 
     HttpHeaders& operator=(const HttpHeaders& that) {
@@ -40,35 +38,22 @@ public:
     std::vector<std::string> keys() const {
         std::vector<std::string> keys;
         keys.reserve(_headers.size());
-        for (auto kv_pair: _headers) {
-            keys.push_back(kv_pair.first);
+        for (const auto& [key, _]: _headers) {
+            keys.push_back(key);
         }
         return keys;
     }
 
-    inline bool contains(const std::string& key) const {
-        return _headers.find(key) != _headers.end();
+    std::string& operator[](const std::string& key) { 
+        return _headers[key];
     }
 
-    bool put(const std::string& key, const std::string& value) {
-        if (contains(key)) {
-            return false;
-        }
-
-        _headers[key] = value;
-        return true;
-    }
-
-    inline std::string get(const std::string& key) const {
+    const std::string& operator[](const std::string& key) const { 
         return _headers.at(key);
     }
 
-    std::string operator[](const std::string& key) const { 
-        return get(key);
-    }
-
-    std::string& operator[](const std::string& key) { 
-        return _headers[key];
+    inline bool contains(const std::string& key) const {
+        return _headers.find(key) != _headers.end();
     }
 
     size_t size() const {

--- a/include/http_headers.h
+++ b/include/http_headers.h
@@ -8,15 +8,15 @@
 
 namespace http {
 
-class HttpHeaders {
+class Headers {
 public:
-    HttpHeaders() = default;
+    Headers() = default;
 
-    HttpHeaders(const HttpHeaders& that): _headers() {
+    Headers(const Headers& that): _headers() {
         this->_headers = that._headers;
     }
 
-    HttpHeaders& operator=(const HttpHeaders& that) {
+    Headers& operator=(const Headers& that) {
         if (this != &that) {
             this->_headers.clear();
             this->_headers = that._headers;
@@ -24,11 +24,11 @@ public:
         return *this;
     }
 
-    HttpHeaders(HttpHeaders&& that) {
+    Headers(Headers&& that) {
         this->_headers = std::move(that._headers);
     }
 
-    HttpHeaders& operator=(HttpHeaders&& that) {
+    Headers& operator=(Headers&& that) {
         if (this != &that) {
             this->_headers = std::move(that._headers);
         }
@@ -63,7 +63,7 @@ public:
     std::string toString() const {
         std::stringstream sstream;
 
-        sstream << "HttpHeaders{headers=[" << std::endl;
+        sstream << "Headers{headers=[" << std::endl;
 
         for (auto i = _headers.begin(); i != _headers.end(); i++) {
             if (i != _headers.begin()) {

--- a/include/http_method.h
+++ b/include/http_method.h
@@ -5,7 +5,7 @@
 
 namespace http {
 
-enum class HttpMethod {
+enum class Method {
     GET,
     HEAD,
     POST,
@@ -17,17 +17,17 @@ enum class HttpMethod {
     PATCH,
 };
 
-inline std::string ConvertHttpMethodToString(const HttpMethod& method) {
+inline std::string ConvertHttpMethodToString(const Method& method) {
     switch (method) {
-        case HttpMethod::GET: return std::string("GET");
-        case HttpMethod::HEAD: return std::string("HEAD");
-        case HttpMethod::POST: return std::string("POST");
-        case HttpMethod::PUT: return std::string("PUT");
-        case HttpMethod::DELETE: return std::string("DELETE");
-        case HttpMethod::CONNECT: return std::string("CONNECT");
-        case HttpMethod::OPTIONS: return std::string("OPTIONS");
-        case HttpMethod::TRACE: return std::string("TRACE");
-        case HttpMethod::PATCH: return std::string("PATCH");
+        case Method::GET: return std::string("GET");
+        case Method::HEAD: return std::string("HEAD");
+        case Method::POST: return std::string("POST");
+        case Method::PUT: return std::string("PUT");
+        case Method::DELETE: return std::string("DELETE");
+        case Method::CONNECT: return std::string("CONNECT");
+        case Method::OPTIONS: return std::string("OPTIONS");
+        case Method::TRACE: return std::string("TRACE");
+        case Method::PATCH: return std::string("PATCH");
         default: return std::string("UNKNOWN");
     }
 }

--- a/include/http_method.h
+++ b/include/http_method.h
@@ -5,29 +5,32 @@
 
 namespace http {
 
+// Http Request methods.
+// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
+// for more info.
 enum class Method {
-    GET,
-    HEAD,
-    POST,
-    PUT,
-    DELETE,
-    CONNECT,
-    OPTIONS,
-    TRACE,
-    PATCH,
+    kGet,
+    kHead,
+    kPost,
+    kPut,
+    kDelete,
+    kConnect,
+    kOptions,
+    kTrace,
+    kPatch,
 };
 
 inline std::string ConvertHttpMethodToString(const Method& method) {
     switch (method) {
-        case Method::GET: return std::string("GET");
-        case Method::HEAD: return std::string("HEAD");
-        case Method::POST: return std::string("POST");
-        case Method::PUT: return std::string("PUT");
-        case Method::DELETE: return std::string("DELETE");
-        case Method::CONNECT: return std::string("CONNECT");
-        case Method::OPTIONS: return std::string("OPTIONS");
-        case Method::TRACE: return std::string("TRACE");
-        case Method::PATCH: return std::string("PATCH");
+        case Method::kGet: return std::string("GET");
+        case Method::kHead: return std::string("HEAD");
+        case Method::kPost: return std::string("POST");
+        case Method::kPut: return std::string("PUT");
+        case Method::kDelete: return std::string("DELETE");
+        case Method::kConnect: return std::string("CONNECT");
+        case Method::kOptions: return std::string("OPTIONS");
+        case Method::kTrace: return std::string("TRACE");
+        case Method::kPatch: return std::string("PATCH");
         default: return std::string("UNKNOWN");
     }
 }

--- a/include/http_request.h
+++ b/include/http_request.h
@@ -30,9 +30,9 @@ std::string ConvertMapToString(const std::unordered_map<K, V>& map) {
 
 namespace http {
 
-class HttpRequest {
+class Request {
 public:
-    HttpRequest(const std::string& http_version,
+    Request(const std::string& http_version,
                 const std::string& path,
                 Method method,
                 Headers headers,
@@ -80,7 +80,7 @@ public:
     std::string toString() const {
         std::stringstream sstream;
 
-        sstream << "HttpRequest{ " << std::endl
+        sstream << "Request{ " << std::endl
                 << "version=" << _http_version << ", " << std::endl
                 << "path=" << _path << ", " << std::endl
                 << "method=" << ConvertHttpMethodToString(_method) << ", " << std::endl
@@ -92,7 +92,7 @@ public:
         return sstream.str();
     }
 
-    ~HttpRequest() = default;
+    ~Request() = default;
 
 private:
     std::string _http_version;

--- a/include/http_request.h
+++ b/include/http_request.h
@@ -33,11 +33,11 @@ namespace http {
 class Request {
 public:
     Request(const std::string& http_version,
-                const std::string& path,
-                Method method,
-                Headers headers,
-                const std::unordered_map<std::string, std::string>& query_parameters,
-                const std::string& body):
+            const std::string& path,
+            const Method& method,
+            const Headers& headers,
+            const std::unordered_map<std::string, std::string>& query_parameters,
+            const std::string& body):
         _http_version(http_version),
         _path(path),
         _method(method),
@@ -47,21 +47,63 @@ public:
         // Empty on purpose.
     }
 
-    // TODO: add copy and move constructors.
+    Request(const Request& that):
+        _http_version(that._http_version),
+        _path(that._path),
+        _method(that._method),
+        _headers(that._headers),
+        _query_parameters(that._query_parameters),
+        _body(that._body) {
+        // Empty on purpose.
+    }
 
-    std::string getHttpVersion() const {
+    Request& operator=(const Request& that) {
+        if (this != &that) {
+            _http_version = that._http_version;
+            _path = that._path;
+            _method = that._method;
+            _headers = that._headers;
+            _query_parameters = that._query_parameters;
+            _body = that._body;
+        }
+        return *this;
+    }
+
+    Request(Request&& that):
+        _http_version(std::move(that._http_version)),
+        _path(std::move(that._path)),
+        _method(std::move(that._method)),
+        _headers(std::move(that._headers)),
+        _query_parameters(std::move(that._query_parameters)),
+        _body(std::move(that._body)) {
+        // Empty on purpose.
+    }
+
+    Request& operator=(Request&& that) {
+        if (this != &that) {
+            _http_version = std::move(that._http_version);
+            _path = std::move(that._path);
+            _method = std::move(that._method);
+            _headers = std::move(that._headers);
+            _query_parameters = std::move(that._query_parameters);
+            _body = std::move(that._body);
+        }
+        return *this;
+    }
+
+    const std::string& getHttpVersion() const {
         return _http_version;
     }
 
-    std::string getPath() const {
+    const std::string& getPath() const {
         return _path;
     }
 
-    http::Method getMethod() const {
+    const http::Method& getMethod() const {
         return _method;
     }
 
-    http::Headers getHeaders() const {
+    const http::Headers& getHeaders() const {
         return _headers;
     }
 
@@ -69,11 +111,11 @@ public:
         return _query_parameters.find(key) != _query_parameters.end();
     }
 
-    std::string getQuery(const std::string& key) const {
+    const std::string& getQuery(const std::string& key) const {
         return _query_parameters.at(key);
     }
 
-    std::string getBody() const {
+    const std::string& getBody() const {
         return _body;
     }
 

--- a/include/http_request.h
+++ b/include/http_request.h
@@ -35,7 +35,7 @@ public:
     HttpRequest(const std::string& http_version,
                 const std::string& path,
                 HttpMethod method,
-                HttpHeaders headers,
+                Headers headers,
                 const std::unordered_map<std::string, std::string>& query_parameters,
                 const std::string& body):
         _http_version(http_version),
@@ -61,7 +61,7 @@ public:
         return _method;
     }
 
-    http::HttpHeaders getHeaders() const {
+    http::Headers getHeaders() const {
         return _headers;
     }
 
@@ -98,7 +98,7 @@ private:
     std::string _http_version;
     std::string _path;
     HttpMethod _method;
-    HttpHeaders _headers;
+    Headers _headers;
     std::unordered_map<std::string, std::string> _query_parameters;
     std::string _body;
 };

--- a/include/http_request.h
+++ b/include/http_request.h
@@ -34,7 +34,7 @@ class HttpRequest {
 public:
     HttpRequest(const std::string& http_version,
                 const std::string& path,
-                HttpMethod method,
+                Method method,
                 Headers headers,
                 const std::unordered_map<std::string, std::string>& query_parameters,
                 const std::string& body):
@@ -57,7 +57,7 @@ public:
         return _path;
     }
 
-    http::HttpMethod getMethod() const {
+    http::Method getMethod() const {
         return _method;
     }
 
@@ -97,7 +97,7 @@ public:
 private:
     std::string _http_version;
     std::string _path;
-    HttpMethod _method;
+    Method _method;
     Headers _headers;
     std::unordered_map<std::string, std::string> _query_parameters;
     std::string _body;

--- a/include/http_response.h
+++ b/include/http_response.h
@@ -15,7 +15,7 @@ namespace http {
 class Response {
 public:
     Response(uint32_t connection_id,
-                 tcp::TcpServer* tcp_server,
+                 tcp::Server* tcp_server,
                  const __internal::Http11Parser& parser):
         _connection_id(connection_id),
         _tcp_server(tcp_server),
@@ -56,7 +56,7 @@ public:
 
 private:
     uint32_t _connection_id;
-    tcp::TcpServer* _tcp_server;
+    tcp::Server* _tcp_server;
     __internal::Http11Parser _parser;
 
     StatusCode _status_code;

--- a/include/http_response.h
+++ b/include/http_response.h
@@ -20,18 +20,18 @@ public:
         _connection_id(connection_id),
         _tcp_server(tcp_server),
         _parser(parser),
-        _status_code(HttpStatusCode::OK),
+        _status_code(StatusCode::OK),
         _headers() {
         // Empty on purpose.
     }
 
     // TODO: add copy and move constructors.
 
-    void setStatusCode(const HttpStatusCode& status_code) {
+    void setStatusCode(const StatusCode& status_code) {
         _status_code = status_code;
     }
 
-    const HttpStatusCode& getStatusCode() const {
+    const StatusCode& getStatusCode() const {
         return _status_code;
     }
 
@@ -59,7 +59,7 @@ private:
     __internal::TcpServer* _tcp_server;
     __internal::Http11Parser _parser;
 
-    HttpStatusCode _status_code;
+    StatusCode _status_code;
     Headers _headers;
 
 

--- a/include/http_response.h
+++ b/include/http_response.h
@@ -20,7 +20,7 @@ public:
         _connection_id(connection_id),
         _tcp_server(tcp_server),
         _parser(parser),
-        _status_code(StatusCode::OK),
+        _status_code(StatusCode::kOk),
         _headers() {
         // Empty on purpose.
     }

--- a/include/http_response.h
+++ b/include/http_response.h
@@ -12,9 +12,9 @@
 
 namespace http {
 
-class HttpResponse {
+class Response {
 public:
-    HttpResponse(uint32_t connection_id,
+    Response(uint32_t connection_id,
                  __internal::TcpServer* tcp_server,
                  const __internal::Http11Parser& parser):
         _connection_id(connection_id),
@@ -52,7 +52,7 @@ public:
         _tcp_server->close(_connection_id);
     }
 
-    ~HttpResponse() = default;
+    ~Response() = default;
 
 private:
     uint32_t _connection_id;

--- a/include/http_response.h
+++ b/include/http_response.h
@@ -15,7 +15,7 @@ namespace http {
 class Response {
 public:
     Response(uint32_t connection_id,
-                 __internal::TcpServer* tcp_server,
+                 tcp::TcpServer* tcp_server,
                  const __internal::Http11Parser& parser):
         _connection_id(connection_id),
         _tcp_server(tcp_server),
@@ -56,7 +56,7 @@ public:
 
 private:
     uint32_t _connection_id;
-    __internal::TcpServer* _tcp_server;
+    tcp::TcpServer* _tcp_server;
     __internal::Http11Parser _parser;
 
     StatusCode _status_code;

--- a/include/http_response.h
+++ b/include/http_response.h
@@ -15,8 +15,8 @@ namespace http {
 class HttpResponse {
 public:
     HttpResponse(uint32_t connection_id,
-                 __http_internal::TcpServer* tcp_server,
-                 const __http_internal::Http11Parser& parser):
+                 __internal::TcpServer* tcp_server,
+                 const __internal::Http11Parser& parser):
         _connection_id(connection_id),
         _tcp_server(tcp_server),
         _parser(parser),
@@ -56,8 +56,8 @@ public:
 
 private:
     uint32_t _connection_id;
-    __http_internal::TcpServer* _tcp_server;
-    __http_internal::Http11Parser _parser;
+    __internal::TcpServer* _tcp_server;
+    __internal::Http11Parser _parser;
 
     HttpStatusCode _status_code;
     HttpHeaders _headers;

--- a/include/http_response.h
+++ b/include/http_response.h
@@ -40,7 +40,7 @@ public:
         _headers[key] = value;
     }
 
-    const HttpHeaders& getHeaders() const {
+    const Headers& getHeaders() const {
         return _headers;
     }
 
@@ -60,7 +60,7 @@ private:
     __internal::Http11Parser _parser;
 
     HttpStatusCode _status_code;
-    HttpHeaders _headers;
+    Headers _headers;
 
 
 };

--- a/include/http_response.h
+++ b/include/http_response.h
@@ -15,8 +15,8 @@ namespace http {
 class Response {
 public:
     Response(uint32_t connection_id,
-                 tcp::Server* tcp_server,
-                 const __internal::Http11Parser& parser):
+            const tcp::Server& tcp_server,
+            const __internal::Http11Parser& parser):
         _connection_id(connection_id),
         _tcp_server(tcp_server),
         _parser(parser),
@@ -24,8 +24,6 @@ public:
         _headers() {
         // Empty on purpose.
     }
-
-    // TODO: add copy and move constructors.
 
     void setStatusCode(const StatusCode& status_code) {
         _status_code = status_code;
@@ -44,25 +42,32 @@ public:
         return _headers;
     }
 
-    void send(const std::string& body) {
+    void send(const std::string& body) const {
         std::string response = _parser.toResponse(*this, body);
         const char* raw_response = response.c_str();
 
-        _tcp_server->write(_connection_id, raw_response, strlen(raw_response));
-        _tcp_server->close(_connection_id);
+        _tcp_server.write(_connection_id, raw_response, strlen(raw_response));
+        _tcp_server.close(_connection_id);
     }
 
     ~Response() = default;
 
 private:
+    Response(const Response& that) = delete;
+    Response& operator=(const Response& that) = delete;
+    Response(Response&& that) = delete;
+    Response& operator=(Response&& that) = delete;
+
     uint32_t _connection_id;
-    tcp::Server* _tcp_server;
-    __internal::Http11Parser _parser;
+
+    // Response always lives no longer
+    // than the server and the parser associated
+    // with it.
+    const tcp::Server& _tcp_server;
+    const __internal::Http11Parser& _parser;
 
     StatusCode _status_code;
     Headers _headers;
-
-
 };
 
 } // namespace http

--- a/include/http_server.h
+++ b/include/http_server.h
@@ -22,7 +22,7 @@ namespace http {
 
 class HttpServer {
   public:
-    typedef std::function<void(const HttpRequest& request, HttpResponse& response)> OnRouteCallback;
+    typedef std::function<void(const Request& request, HttpResponse& response)> OnRouteCallback;
 
     HttpServer(uint16_t port,
                uint8_t max_connections = kDefaultMaxConnection);

--- a/include/http_server.h
+++ b/include/http_server.h
@@ -42,17 +42,22 @@ class Server {
     ~Server() = default;
 
   private:
+    uint16_t _port;
+    uint8_t _max_connections;
+    tcp::Server _tcp_server;
+    std::unordered_map<Method, std::unordered_map<std::string, OnRouteCallback>> _routes;
+
+    Server(const Server& that) = delete;
+    Server& operator=(const Server& that) = delete;
+    Server(Server&& that) = delete;
+    Server& operator=(Server&& that) = delete;
+
     const OnRouteCallback* findRouteCallback(const Method& method,
                                        const std::string& route) const;
 
     void onMethod(const Method& method,
                   const std::string& route,
                   OnRouteCallback callback);
-
-    uint16_t _port;
-    uint8_t _max_connections;
-    std::unique_ptr<tcp::Server> _tcp_server;
-    std::unordered_map<Method, std::unordered_map<std::string, OnRouteCallback>> _routes;
 };
 
 }

--- a/include/http_server.h
+++ b/include/http_server.h
@@ -29,12 +29,12 @@ class HttpServer {
 
     inline void onGet(const std::string& route,
                       OnRouteCallback callback) {
-      onMethod(HttpMethod::GET, route, callback);
+      onMethod(Method::GET, route, callback);
     }
 
     inline void onPost(const std::string& route,
                        OnRouteCallback callback) {
-      onMethod(HttpMethod::POST, route, callback);
+      onMethod(Method::POST, route, callback);
     }
 
     void start();
@@ -42,17 +42,17 @@ class HttpServer {
     ~HttpServer() = default;
 
   private:
-    const OnRouteCallback* findRouteCallback(const HttpMethod& method,
+    const OnRouteCallback* findRouteCallback(const Method& method,
                                        const std::string& route) const;
 
-    void onMethod(const HttpMethod& method,
+    void onMethod(const Method& method,
                   const std::string& route,
                   OnRouteCallback callback);
 
     uint16_t _port;
     uint8_t _max_connections;
     std::unique_ptr<__internal::TcpServer> _tcp_server;
-    std::unordered_map<HttpMethod, std::unordered_map<std::string, OnRouteCallback>> _routes;
+    std::unordered_map<Method, std::unordered_map<std::string, OnRouteCallback>> _routes;
 };
 
 }

--- a/include/http_server.h
+++ b/include/http_server.h
@@ -51,7 +51,7 @@ class HttpServer {
 
     uint16_t _port;
     uint8_t _max_connections;
-    std::unique_ptr<__http_internal::TcpServer> _tcp_server;
+    std::unique_ptr<__internal::TcpServer> _tcp_server;
     std::unordered_map<HttpMethod, std::unordered_map<std::string, OnRouteCallback>> _routes;
 };
 

--- a/include/http_server.h
+++ b/include/http_server.h
@@ -51,7 +51,7 @@ class Server {
 
     uint16_t _port;
     uint8_t _max_connections;
-    std::unique_ptr<tcp::TcpServer> _tcp_server;
+    std::unique_ptr<tcp::Server> _tcp_server;
     std::unordered_map<Method, std::unordered_map<std::string, OnRouteCallback>> _routes;
 };
 

--- a/include/http_server.h
+++ b/include/http_server.h
@@ -22,7 +22,7 @@ namespace http {
 
 class HttpServer {
   public:
-    typedef std::function<void(const Request& request, HttpResponse& response)> OnRouteCallback;
+    typedef std::function<void(const Request& request, Response& response)> OnRouteCallback;
 
     HttpServer(uint16_t port,
                uint8_t max_connections = kDefaultMaxConnection);

--- a/include/http_server.h
+++ b/include/http_server.h
@@ -25,7 +25,7 @@ class Server {
     typedef std::function<void(const Request& request, Response& response)> OnRouteCallback;
 
     Server(uint16_t port,
-               uint8_t max_connections = kDefaultMaxConnection);
+           uint8_t max_connections = kDefaultMaxConnection);
 
     inline void onGet(const std::string& route,
                       OnRouteCallback callback) {
@@ -51,7 +51,7 @@ class Server {
 
     uint16_t _port;
     uint8_t _max_connections;
-    std::unique_ptr<__internal::TcpServer> _tcp_server;
+    std::unique_ptr<tcp::TcpServer> _tcp_server;
     std::unordered_map<Method, std::unordered_map<std::string, OnRouteCallback>> _routes;
 };
 

--- a/include/http_server.h
+++ b/include/http_server.h
@@ -20,11 +20,11 @@ constexpr uint8_t kDefaultMaxConnection = 8;
 
 namespace http {
 
-class HttpServer {
+class Server {
   public:
     typedef std::function<void(const Request& request, Response& response)> OnRouteCallback;
 
-    HttpServer(uint16_t port,
+    Server(uint16_t port,
                uint8_t max_connections = kDefaultMaxConnection);
 
     inline void onGet(const std::string& route,
@@ -39,7 +39,7 @@ class HttpServer {
 
     void start();
 
-    ~HttpServer() = default;
+    ~Server() = default;
 
   private:
     const OnRouteCallback* findRouteCallback(const Method& method,

--- a/include/http_server.h
+++ b/include/http_server.h
@@ -29,12 +29,12 @@ class Server {
 
     inline void onGet(const std::string& route,
                       OnRouteCallback callback) {
-      onMethod(Method::GET, route, callback);
+      onMethod(Method::kGet, route, callback);
     }
 
     inline void onPost(const std::string& route,
                        OnRouteCallback callback) {
-      onMethod(Method::POST, route, callback);
+      onMethod(Method::kPost, route, callback);
     }
 
     void start();

--- a/include/http_status_code.h
+++ b/include/http_status_code.h
@@ -3,7 +3,7 @@
 
 namespace http {
 
-enum class HttpStatusCode {
+enum class StatusCode {
     OK,
     BAD_REQUEST,
     UNAUTHORIZED,

--- a/include/http_status_code.h
+++ b/include/http_status_code.h
@@ -3,13 +3,84 @@
 
 namespace http {
 
+// Http Response Status codes, see mdn docs for more info:
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status.
 enum class StatusCode {
-    OK,
-    BAD_REQUEST,
-    UNAUTHORIZED,
-    FORBIDDEN,
-    NOT_FOUND,
-    INTERNAL_SERVER_ERROR,
+    // Information responses.
+    kContinue = 100,
+    kSwitchingProtocols = 101,
+    kProcessing = 102,
+    kEarlyHints = 103,
+
+    // Successful responses.
+    kOk = 200,
+    kCreated = 201,
+    kAccepted = 202,
+    kNonAuthoritativeInformation = 203,
+    kNoContent = 204,
+    kResetContent = 205,
+    kPartialContent = 206,
+    kMultiStatus = 207,
+    kAlreadyReported = 208,
+    kIMUsed = 226,
+
+    // Redirection messages.
+    kMultipleChoices = 300,
+    kMovedPermanently = 301,
+    kFound = 302,
+    kSeeOther = 303,
+    kNotModified = 304,
+    //  Deprecated.
+    kUseProxy = 305,
+    //  306 is unused.
+    kTemporaryRedirect = 307,
+    kPermanentRedirect = 308,
+
+    // Client error responses.
+    kBadRequest = 400,
+    kUnauthorized = 401,
+    //  Experimental.
+    kPaymentRequired = 402,
+    kForbidden = 403,
+    kNotFound = 404,
+    kMethodNotAllowed = 405,
+    kNotAcceptable = 406,
+    kProxyAuthenticationRequired = 407,
+    kRequestTimeout = 408,
+    kConflict = 409,
+    kGone = 410,
+    kLengthRequired = 411,
+    kPreconditionFailed = 412,
+    kPayloadTooLarge = 413,
+    kUriTooLong = 414,
+    kUnsupportedMediaType = 415,
+    kRangeNotSatisfiable = 416,
+    kExpectationFailed = 417,
+    kImATeapot = 418,
+    kMisdirectedRequest = 421,
+    kUnprocessableContent = 422,
+    kLocked = 423,
+    kFailedDependency = 424,
+    //  Experimental.
+    kTooEarly = 425,
+    kUpgradeRequired = 426,
+    kPreconditionRequired = 428,
+    kTooManyRequests = 429,
+    kRequestHeaderFieldsTooLarge = 431,
+    kUnavailableForLegalReasons = 451,
+
+    // Server error responses.
+    kInternalServerError = 500,
+    kNotImplemented = 501,
+    kBadGateway = 502,
+    kServiceUnavailable = 503,
+    kGatewayTimeout = 504,
+    kHttpVersionNotSupported = 505,
+    kVariantAlsoNegotiates = 506,
+    kInsufficientStorage = 507,
+    kLoopDetected = 508,
+    kNotExtended = 510,
+    kNetworkAuthenticationRequired = 511,
 };
 
 } // namespace http

--- a/include/http_status_code.h
+++ b/include/http_status_code.h
@@ -3,8 +3,9 @@
 
 namespace http {
 
-// Http Response Status codes, see mdn docs for more info:
-// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status.
+// Http Response Status codes.
+// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+// for more info.
 enum class StatusCode {
     // Information responses.
     kContinue = 100,

--- a/include/tcp_connection.h
+++ b/include/tcp_connection.h
@@ -8,11 +8,11 @@ struct pbuf;
 
 namespace tcp {
 
-class TcpServer;
+class Server;
 
 class TcpConnection {
 public:
-    TcpConnection(TcpServer& server,
+    TcpConnection(Server& server,
                   tcp_pcb* pcb):
         _is_closing(false),
         _server(server),
@@ -25,7 +25,7 @@ public:
     }
 
     inline tcp_pcb* getPcb() { return _pcb; }
-    inline TcpServer& getServer() { return _server; }
+    inline Server& getServer() { return _server; }
 
     inline bool isClosing() const { return _is_closing; }
     inline void close() { _is_closing = true; }
@@ -40,7 +40,7 @@ private:
     TcpConnection& operator=(const TcpConnection& that) = delete;
 
     tcp_pcb* _pcb;
-    TcpServer& _server;
+    Server& _server;
 
     bool _is_closing;
 };

--- a/include/tcp_connection.h
+++ b/include/tcp_connection.h
@@ -13,10 +13,10 @@ class Server;
 class Connection {
 public:
     Connection(Server& server,
-                  tcp_pcb* pcb):
-        _is_closing(false),
+               tcp_pcb& pcb):
         _server(server),
-        _pcb(pcb) {
+        _pcb(pcb),
+        _is_closing(false) {
         // Empty on purpose.
     }
 
@@ -24,11 +24,11 @@ public:
         return reinterpret_cast<uint32_t>(this);
     }
 
-    inline tcp_pcb* getPcb() { return _pcb; }
-    inline Server& getServer() { return _server; }
+    inline tcp_pcb& getPcb() const { return _pcb; }
+    inline Server& getServer() const { return _server; }
 
-    inline bool isClosing() const { return _is_closing; }
     inline void close() { _is_closing = true; }
+    inline bool isClosing() const { return _is_closing; }
 
     bool sink(pbuf* pbuf);
     bool write(const void* data, uint16_t size) const;
@@ -36,13 +36,19 @@ public:
     bool flush() const;
 
 private:
-    Connection(const Connection& that) = delete;
-    Connection& operator=(const Connection& that) = delete;
-
-    tcp_pcb* _pcb;
+    // Connection does not own neither server nor pcb,
+    // connection just observes them and interacts.
     Server& _server;
+    tcp_pcb& _pcb;
 
     bool _is_closing;
+
+    // Connection cannot be copied or moved,
+    // only non-owning raw pointer can be passed.
+    Connection(const Connection& that) = delete;
+    Connection& operator=(const Connection& that) = delete;
+    Connection(Connection&& that) = delete;
+    Connection& operator=(Connection&& that) = delete;
 };
 
 } // namespace tcp

--- a/include/tcp_connection.h
+++ b/include/tcp_connection.h
@@ -6,7 +6,9 @@
 struct tcp_pcb;
 struct pbuf;
 
-namespace __http_internal {
+namespace http {
+
+namespace __internal {
 
 class TcpServer;
 
@@ -45,6 +47,8 @@ private:
     bool _is_closing;
 };
 
-} // namespace __http_internal
+} // namespace __internal
+
+} // namespace http
 
 #endif // __TCP_CONNECTION_H__

--- a/include/tcp_connection.h
+++ b/include/tcp_connection.h
@@ -10,9 +10,9 @@ namespace tcp {
 
 class Server;
 
-class TcpConnection {
+class Connection {
 public:
-    TcpConnection(Server& server,
+    Connection(Server& server,
                   tcp_pcb* pcb):
         _is_closing(false),
         _server(server),
@@ -36,8 +36,8 @@ public:
     bool flush() const;
 
 private:
-    TcpConnection(const TcpConnection& that) = delete;
-    TcpConnection& operator=(const TcpConnection& that) = delete;
+    Connection(const Connection& that) = delete;
+    Connection& operator=(const Connection& that) = delete;
 
     tcp_pcb* _pcb;
     Server& _server;

--- a/include/tcp_connection.h
+++ b/include/tcp_connection.h
@@ -6,9 +6,7 @@
 struct tcp_pcb;
 struct pbuf;
 
-namespace http {
-
-namespace __internal {
+namespace tcp {
 
 class TcpServer;
 
@@ -47,8 +45,6 @@ private:
     bool _is_closing;
 };
 
-} // namespace __internal
-
-} // namespace http
+} // namespace tcp
 
 #endif // __TCP_CONNECTION_H__

--- a/include/tcp_server.h
+++ b/include/tcp_server.h
@@ -12,13 +12,13 @@ struct tcp_pcb;
 
 namespace tcp {
 
-class TcpServer {
+class Server {
 public:
     typedef std::function<void(uint32_t connection_id)> OnConnectedCallback;
     typedef std::function<bool(uint32_t connection_id, uint8_t* data, uint16_t size)> OnDataReceivedCallback;
     typedef std::function<void(uint32_t connection_id)> OnClosedCallback;
 
-    TcpServer(uint8_t max_connections):
+    Server(uint8_t max_connections):
         _max_connections(max_connections) {
         // Empty on purpose.
     }
@@ -47,11 +47,11 @@ public:
     bool listen(uint16_t port);
     bool stop();
 
-    ~TcpServer() = default;
+    ~Server() = default;
 
 private:
-    TcpServer(const TcpServer& that) = delete;
-    TcpServer& operator=(const TcpServer& that) = delete;
+    Server(const Server& that) = delete;
+    Server& operator=(const Server& that) = delete;
 
     // TODO: add destructor to clear resources and stop listeners.
 

--- a/include/tcp_server.h
+++ b/include/tcp_server.h
@@ -35,11 +35,11 @@ public:
         _onClosedCallback = callback;
     }
 
-    TcpConnection* createConnection(tcp_pcb* pcb);
+    Connection* createConnection(tcp_pcb* pcb);
 
-    void onConnected(TcpConnection* connection);
-    bool onDataReceived(TcpConnection* connection, uint8_t* data, uint16_t size);
-    void onConnectionClosed(TcpConnection* connection);
+    void onConnected(Connection* connection);
+    bool onDataReceived(Connection* connection, uint8_t* data, uint16_t size);
+    void onConnectionClosed(Connection* connection);
 
     bool write(uint32_t connection_id, const void* data, uint16_t size) const;
     void close(uint32_t connection_id) const;
@@ -55,7 +55,7 @@ private:
 
     // TODO: add destructor to clear resources and stop listeners.
 
-    inline TcpConnection* findConnectionById(uint32_t connection_id) const {
+    inline Connection* findConnectionById(uint32_t connection_id) const {
         if (_connections.find(connection_id) == _connections.end()) {
             return nullptr;
         }
@@ -64,7 +64,7 @@ private:
 
     uint8_t _max_connections;
     tcp_pcb* _listen_pcb = nullptr;
-    std::unordered_map<uint32_t, std::unique_ptr<TcpConnection>> _connections;
+    std::unordered_map<uint32_t, std::unique_ptr<Connection>> _connections;
 
     OnConnectedCallback _onConnectedCallback = nullptr;
     OnDataReceivedCallback _onDataReceivedCallback = nullptr;

--- a/include/tcp_server.h
+++ b/include/tcp_server.h
@@ -52,8 +52,8 @@ public:
 private:
     Server(const Server& that) = delete;
     Server& operator=(const Server& that) = delete;
-
-    // TODO: add destructor to clear resources and stop listeners.
+    Server(Server&& that) = delete;
+    Server& operator=(Server&& that) = delete;
 
     inline Connection* findConnectionById(uint32_t connection_id) const {
         if (_connections.find(connection_id) == _connections.end()) {

--- a/include/tcp_server.h
+++ b/include/tcp_server.h
@@ -37,8 +37,8 @@ public:
 
     Connection* createConnection(tcp_pcb* pcb);
 
-    void onConnected(Connection* connection);
-    bool onDataReceived(Connection* connection, uint8_t* data, uint16_t size);
+    void onConnected(Connection* connection) const;
+    bool onDataReceived(Connection* connection, uint8_t* data, uint16_t size) const;
     void onConnectionClosed(Connection* connection);
 
     bool write(uint32_t connection_id, const void* data, uint16_t size) const;
@@ -47,9 +47,17 @@ public:
     bool listen(uint16_t port);
     bool stop();
 
-    ~Server() = default;
+    ~Server();
 
 private:
+    uint8_t _max_connections;
+    tcp_pcb* _listen_pcb = nullptr;
+    std::unordered_map<uint32_t, std::unique_ptr<Connection>> _connections;
+
+    OnConnectedCallback _onConnectedCallback = nullptr;
+    OnDataReceivedCallback _onDataReceivedCallback = nullptr;
+    OnClosedCallback _onClosedCallback = nullptr;
+
     Server(const Server& that) = delete;
     Server& operator=(const Server& that) = delete;
     Server(Server&& that) = delete;
@@ -61,14 +69,6 @@ private:
         }
         return _connections.at(connection_id).get();
     }
-
-    uint8_t _max_connections;
-    tcp_pcb* _listen_pcb = nullptr;
-    std::unordered_map<uint32_t, std::unique_ptr<Connection>> _connections;
-
-    OnConnectedCallback _onConnectedCallback = nullptr;
-    OnDataReceivedCallback _onDataReceivedCallback = nullptr;
-    OnClosedCallback _onClosedCallback = nullptr;
 };
 
 } // namespace tcp

--- a/include/tcp_server.h
+++ b/include/tcp_server.h
@@ -10,7 +10,9 @@
 
 struct tcp_pcb;
 
-namespace __http_internal {
+namespace http {
+
+namespace __internal {
 
 class TcpServer {
 public:
@@ -71,6 +73,8 @@ private:
     OnClosedCallback _onClosedCallback = nullptr;
 };
 
-} // __http_internal
+} // __internal
+
+} // namespace http
 
 #endif // __TCP_SERVER_H__

--- a/include/tcp_server.h
+++ b/include/tcp_server.h
@@ -10,9 +10,7 @@
 
 struct tcp_pcb;
 
-namespace http {
-
-namespace __internal {
+namespace tcp {
 
 class TcpServer {
 public:
@@ -73,8 +71,6 @@ private:
     OnClosedCallback _onClosedCallback = nullptr;
 };
 
-} // __internal
-
-} // namespace http
+} // namespace tcp
 
 #endif // __TCP_SERVER_H__

--- a/src/http1_1_parser.cpp
+++ b/src/http1_1_parser.cpp
@@ -49,7 +49,7 @@ http::HttpRequest Http11Parser::fromRequest(const std::string& request) const {
         std::string key;
         std::string value;
         if (ParseSingleHeaderLine(header_candidate, key, value)) {
-            headers.put(key, value);
+            headers[key] = value;
         }
 
         headers_line++;

--- a/src/http1_1_parser.cpp
+++ b/src/http1_1_parser.cpp
@@ -21,7 +21,9 @@ constexpr char kHttpWordsDelimiter = ' ';
 
 } // namespace
 
-namespace __http_internal {
+namespace http {
+
+namespace __internal {
 
 http::HttpRequest Http11Parser::fromRequest(const std::string& request) const {
     std::vector<std::string> requst_split = Split(request, /* delimiter= */ std::string(kHttpNewLine));
@@ -84,4 +86,6 @@ std::string Http11Parser::toResponse(const http::HttpResponse& response, const s
     return sstream.str();
 }
 
-} // namespace __http_internal
+} // namespace __internal
+
+} // namespace http

--- a/src/http1_1_parser.cpp
+++ b/src/http1_1_parser.cpp
@@ -35,7 +35,7 @@ http::HttpRequest Http11Parser::fromRequest(const std::string& request) const {
     std::string route = GetRoute(raw_route);
     std::unordered_map<std::string, std::string> query_parameters = ParseQueryParameters(raw_route);
 
-    http::HttpMethod http_method = ConvertStringToHttpMethod(start_line_split[0]);
+    http::Method http_method = ConvertStringToHttpMethod(start_line_split[0]);
     std::string http_version = start_line_split[2];
 
     http::Headers headers;

--- a/src/http1_1_parser.cpp
+++ b/src/http1_1_parser.cpp
@@ -66,7 +66,7 @@ http::Request Http11Parser::fromRequest(const std::string& request) const {
     return http::Request(http_version, route, http_method, headers, query_parameters, Trim(body.str()));
 }
 
-std::string Http11Parser::toResponse(const http::HttpResponse& response, const std::string& body) const {
+std::string Http11Parser::toResponse(const http::Response& response, const std::string& body) const {
     std::stringstream sstream;
 
     // Main line: HTTP/1.1 403 Forbidden

--- a/src/http1_1_parser.cpp
+++ b/src/http1_1_parser.cpp
@@ -38,7 +38,7 @@ http::HttpRequest Http11Parser::fromRequest(const std::string& request) const {
     http::HttpMethod http_method = ConvertStringToHttpMethod(start_line_split[0]);
     std::string http_version = start_line_split[2];
 
-    http::HttpHeaders headers;
+    http::Headers headers;
 
     size_t headers_line = 1;
     while (headers_line < requst_split.size()) {

--- a/src/http1_1_parser.cpp
+++ b/src/http1_1_parser.cpp
@@ -25,7 +25,7 @@ namespace http {
 
 namespace __internal {
 
-http::HttpRequest Http11Parser::fromRequest(const std::string& request) const {
+http::Request Http11Parser::fromRequest(const std::string& request) const {
     std::vector<std::string> requst_split = Split(request, /* delimiter= */ std::string(kHttpNewLine));
 
     std::string start_line = requst_split[0];
@@ -63,7 +63,7 @@ http::HttpRequest Http11Parser::fromRequest(const std::string& request) const {
         headers_line++;
     }
 
-    return http::HttpRequest(http_version, route, http_method, headers, query_parameters, Trim(body.str()));
+    return http::Request(http_version, route, http_method, headers, query_parameters, Trim(body.str()));
 }
 
 std::string Http11Parser::toResponse(const http::HttpResponse& response, const std::string& body) const {

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -28,7 +28,7 @@ HttpServer::HttpServer(uint16_t port, uint8_t max_connections):
     });
 }
 
-const HttpServer::OnRouteCallback* HttpServer::findRouteCallback(const HttpMethod& method,
+const HttpServer::OnRouteCallback* HttpServer::findRouteCallback(const Method& method,
                                                const std::string& route) const {
     if (_routes.find(method) == _routes.end()) {
         return nullptr;
@@ -41,7 +41,7 @@ const HttpServer::OnRouteCallback* HttpServer::findRouteCallback(const HttpMetho
     return &(_routes.at(method).at(route));
 }
 
-void HttpServer::onMethod(const HttpMethod& method,
+void HttpServer::onMethod(const Method& method,
                           const std::string& route,
                           OnRouteCallback callback) {
     if (_routes.find(method) == _routes.end()) {

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -16,7 +16,7 @@ namespace http {
 HttpServer::HttpServer(uint16_t port, uint8_t max_connections):
     _port(port),
     _max_connections(max_connections),
-    _tcp_server(std::make_unique<__http_internal::TcpServer>(max_connections)),
+    _tcp_server(std::make_unique<__internal::TcpServer>(max_connections)),
     _routes() {
 
     _tcp_server->setOnConnectedCallback([](uint32_t connection_id) {
@@ -58,7 +58,7 @@ void HttpServer::start() {
         std::string payload(data, data + length);
 
         // TODO(st235): add parser interface.
-        __http_internal::Http11Parser http_parser;
+        __internal::Http11Parser http_parser;
         const auto& http_request = http_parser.fromRequest(payload);
 
         const auto* callback = this->findRouteCallback(http_request.getMethod(), http_request.getPath());

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -63,7 +63,7 @@ void HttpServer::start() {
 
         const auto* callback = this->findRouteCallback(http_request.getMethod(), http_request.getPath());
 
-        HttpResponse response(connection_id, tcp_server, http_parser);
+        Response response(connection_id, tcp_server, http_parser);
 
         if (!callback) {
             response.send("");

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -63,7 +63,7 @@ void Server::start() {
 
         const auto* callback = this->findRouteCallback(http_request.getMethod(), http_request.getPath());
 
-        Response response(connection_id, tcp_server, http_parser);
+        Response response(connection_id, *tcp_server, http_parser);
 
         if (!callback) {
             response.send("");

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -16,7 +16,7 @@ namespace http {
 Server::Server(uint16_t port, uint8_t max_connections):
     _port(port),
     _max_connections(max_connections),
-    _tcp_server(std::make_unique<tcp::TcpServer>(max_connections)),
+    _tcp_server(std::make_unique<tcp::Server>(max_connections)),
     _routes() {
 
     _tcp_server->setOnConnectedCallback([](uint32_t connection_id) {

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -13,7 +13,7 @@
 
 namespace http {
 
-HttpServer::HttpServer(uint16_t port, uint8_t max_connections):
+Server::Server(uint16_t port, uint8_t max_connections):
     _port(port),
     _max_connections(max_connections),
     _tcp_server(std::make_unique<__internal::TcpServer>(max_connections)),
@@ -28,7 +28,7 @@ HttpServer::HttpServer(uint16_t port, uint8_t max_connections):
     });
 }
 
-const HttpServer::OnRouteCallback* HttpServer::findRouteCallback(const Method& method,
+const Server::OnRouteCallback* Server::findRouteCallback(const Method& method,
                                                const std::string& route) const {
     if (_routes.find(method) == _routes.end()) {
         return nullptr;
@@ -41,7 +41,7 @@ const HttpServer::OnRouteCallback* HttpServer::findRouteCallback(const Method& m
     return &(_routes.at(method).at(route));
 }
 
-void HttpServer::onMethod(const Method& method,
+void Server::onMethod(const Method& method,
                           const std::string& route,
                           OnRouteCallback callback) {
     if (_routes.find(method) == _routes.end()) {
@@ -51,7 +51,7 @@ void HttpServer::onMethod(const Method& method,
     _routes[method][route] = callback;
 }
 
-void HttpServer::start() {
+void Server::start() {
     auto* tcp_server = _tcp_server.get();
 
     _tcp_server->setOnDataReceivedCallback([=, tcp_server](uint32_t connection_id, uint8_t* data, uint16_t length) {

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -16,7 +16,7 @@ namespace http {
 Server::Server(uint16_t port, uint8_t max_connections):
     _port(port),
     _max_connections(max_connections),
-    _tcp_server(std::make_unique<__internal::TcpServer>(max_connections)),
+    _tcp_server(std::make_unique<tcp::TcpServer>(max_connections)),
     _routes() {
 
     _tcp_server->setOnConnectedCallback([](uint32_t connection_id) {

--- a/src/http_utils.h
+++ b/src/http_utils.h
@@ -34,26 +34,26 @@ namespace __internal {
 
 http::Method ConvertStringToHttpMethod(const std::string& method) {
     if (method == "GET") {
-        return http::Method::GET;
+        return http::Method::kGet;
     } else if (method == "HEAD") {
-        return http::Method::HEAD;
+        return http::Method::kHead;
     } else if (method == "POST") {
-        return http::Method::POST;
+        return http::Method::kPost;
     } else if (method == "PUT") {
-        return http::Method::PUT;
+        return http::Method::kPut;
     } else if (method == "DELETE") {
-        return http::Method::DELETE;
+        return http::Method::kDelete;
     } else if (method == "CONNECT") {
-        return http::Method::CONNECT;
+        return http::Method::kConnect;
     } else if (method == "OPTIONS") {
-        return http::Method::OPTIONS;
+        return http::Method::kOptions;
     } else if (method == "TRACE") {
-        return http::Method::TRACE;
+        return http::Method::kTrace;
     } else if (method == "PATCH") {
-        return http::Method::PATCH;
+        return http::Method::kPatch;
     } else {
         // TODO: return some unknown type.
-        return http::Method::GET;
+        return http::Method::kGet;
     }
 }
 

--- a/src/http_utils.h
+++ b/src/http_utils.h
@@ -32,28 +32,28 @@ namespace http {
 
 namespace __internal {
 
-http::HttpMethod ConvertStringToHttpMethod(const std::string& method) {
+http::Method ConvertStringToHttpMethod(const std::string& method) {
     if (method == "GET") {
-        return http::HttpMethod::GET;
+        return http::Method::GET;
     } else if (method == "HEAD") {
-        return http::HttpMethod::HEAD;
+        return http::Method::HEAD;
     } else if (method == "POST") {
-        return http::HttpMethod::POST;
+        return http::Method::POST;
     } else if (method == "PUT") {
-        return http::HttpMethod::PUT;
+        return http::Method::PUT;
     } else if (method == "DELETE") {
-        return http::HttpMethod::DELETE;
+        return http::Method::DELETE;
     } else if (method == "CONNECT") {
-        return http::HttpMethod::CONNECT;
+        return http::Method::CONNECT;
     } else if (method == "OPTIONS") {
-        return http::HttpMethod::OPTIONS;
+        return http::Method::OPTIONS;
     } else if (method == "TRACE") {
-        return http::HttpMethod::TRACE;
+        return http::Method::TRACE;
     } else if (method == "PATCH") {
-        return http::HttpMethod::PATCH;
+        return http::Method::PATCH;
     } else {
         // TODO: return some unknown type.
-        return http::HttpMethod::GET;
+        return http::Method::GET;
     }
 }
 

--- a/src/http_utils.h
+++ b/src/http_utils.h
@@ -59,12 +59,13 @@ http::Method ConvertStringToHttpMethod(const std::string& method) {
 
 std::string GetHttpStatusCodeDescription(const http::StatusCode& status_code) {
     switch(status_code) {
-        case http::StatusCode::OK: return std::string("200 OK");
-        case http::StatusCode::BAD_REQUEST: return std::string("400 Bad Request");
-        case http::StatusCode::UNAUTHORIZED: return std::string("401 Unauthorized");
-        case http::StatusCode::FORBIDDEN: return std::string("403 Forbidden");
-        case http::StatusCode::NOT_FOUND: return std::string("404 Not Found");
-        case http::StatusCode::INTERNAL_SERVER_ERROR: return std::string("500 Internal Server Error");
+        case http::StatusCode::kOk: return std::string("200 OK");
+        case http::StatusCode::kBadRequest: return std::string("400 Bad Request");
+        case http::StatusCode::kUnauthorized: return std::string("401 Unauthorized");
+        case http::StatusCode::kForbidden: return std::string("403 Forbidden");
+        case http::StatusCode::kNotFound: return std::string("404 Not Found");
+        case http::StatusCode::kInternalServerError: return std::string("500 Internal Server Error");
+        // TODO(st235): add all conversions.
         default: return std::string("418 I'm a teapot");
     }
 }

--- a/src/http_utils.h
+++ b/src/http_utils.h
@@ -20,15 +20,17 @@ bool ParseKeyValueStatement(const std::string& statement,
         return false;
     }
 
-    key = __http_internal::Trim(statement.substr(0, delimiter_position));
-    value = __http_internal::Trim(statement.substr(delimiter_position + 1, statement.length() - delimiter_position - 1));
+    key = http::__internal::Trim(statement.substr(0, delimiter_position));
+    value = http::__internal::Trim(statement.substr(delimiter_position + 1, statement.length() - delimiter_position - 1));
 
     return !key.empty() && !value.empty();
 }
 
 }  // namespace
 
-namespace __http_internal {
+namespace http {
+
+namespace __internal {
 
 http::HttpMethod ConvertStringToHttpMethod(const std::string& method) {
     if (method == "GET") {
@@ -106,6 +108,8 @@ bool ParseSingleHeaderLine(const std::string& header,
     return ParseKeyValueStatement(header, /* delimiter= */ ':', key, value);
 }
 
-} // namespace __http_internal
+} // namespace __internal
+
+} // namespace http
 
 #endif // __HTTP_UTILS_H__

--- a/src/http_utils.h
+++ b/src/http_utils.h
@@ -57,14 +57,14 @@ http::Method ConvertStringToHttpMethod(const std::string& method) {
     }
 }
 
-std::string GetHttpStatusCodeDescription(const http::HttpStatusCode& status_code) {
+std::string GetHttpStatusCodeDescription(const http::StatusCode& status_code) {
     switch(status_code) {
-        case http::HttpStatusCode::OK: return std::string("200 OK");
-        case http::HttpStatusCode::BAD_REQUEST: return std::string("400 Bad Request");
-        case http::HttpStatusCode::UNAUTHORIZED: return std::string("401 Unauthorized");
-        case http::HttpStatusCode::FORBIDDEN: return std::string("403 Forbidden");
-        case http::HttpStatusCode::NOT_FOUND: return std::string("404 Not Found");
-        case http::HttpStatusCode::INTERNAL_SERVER_ERROR: return std::string("500 Internal Server Error");
+        case http::StatusCode::OK: return std::string("200 OK");
+        case http::StatusCode::BAD_REQUEST: return std::string("400 Bad Request");
+        case http::StatusCode::UNAUTHORIZED: return std::string("401 Unauthorized");
+        case http::StatusCode::FORBIDDEN: return std::string("403 Forbidden");
+        case http::StatusCode::NOT_FOUND: return std::string("404 Not Found");
+        case http::StatusCode::INTERNAL_SERVER_ERROR: return std::string("500 Internal Server Error");
         default: return std::string("418 I'm a teapot");
     }
 }

--- a/src/http_version.h
+++ b/src/http_version.h
@@ -1,10 +1,14 @@
 #ifndef __HTTP_VERSION_H__
 #define __HTTP_VERSION_H__
 
-namespace __http_internal {
+namespace http {
+
+namespace __internal {
 
 constexpr char kHttp11Version[] = "HTTP/1.1";
 
-} // namespace __http_internal
+} // namespace __internal
+
+} // namespace http
 
 #endif // __HTTP_VERSION_H__

--- a/src/string_utils.h
+++ b/src/string_utils.h
@@ -7,7 +7,9 @@
 
 #include "log.h"
 
-namespace __http_internal {
+namespace http {
+
+namespace __internal {
 
 std::vector<std::string> Split(const std::string& text, const std::string& delimiter) {
     std::vector<std::string> split;
@@ -55,6 +57,8 @@ std::string Trim(const std::string& origin) {
     return origin.substr(start_position, (end_position - start_position + 1));
 }
 
-} // namespace __http_internal
+} // namespace __internal
+
+} // namespace http
 
 #endif // __STRING_UTILS_H__

--- a/src/tcp_connection.cpp
+++ b/src/tcp_connection.cpp
@@ -5,9 +5,7 @@
 #include "log.h"
 #include "tcp_server.h"
 
-namespace http {
-
-namespace __internal {
+namespace tcp {
 
 bool TcpConnection::sink(pbuf* pbuf) {
     uint8_t* data = new uint8_t[pbuf->tot_len];
@@ -51,6 +49,4 @@ bool TcpConnection::flush() const {
     return tcp_output(_pcb) == ERR_OK;
 }
 
-} // namespace __internal
-
-} // namespace http
+} // namespace tcp

--- a/src/tcp_connection.cpp
+++ b/src/tcp_connection.cpp
@@ -7,7 +7,7 @@
 
 namespace tcp {
 
-bool TcpConnection::sink(pbuf* pbuf) {
+bool Connection::sink(pbuf* pbuf) {
     uint8_t* data = new uint8_t[pbuf->tot_len];
     for (uint16_t i = 0; i < pbuf->tot_len; i++) {
         data[i] = pbuf_get_at(pbuf, i);
@@ -21,7 +21,7 @@ bool TcpConnection::sink(pbuf* pbuf) {
     return sink_status;
 }
 
-bool TcpConnection::write(const void* data, uint16_t size) const {
+bool Connection::write(const void* data, uint16_t size) const {
     if (_is_closing) {
         PLOGD("Accessing closed connection.");
         return false;
@@ -40,7 +40,7 @@ bool TcpConnection::write(const void* data, uint16_t size) const {
     return tcp_write(_pcb, data, size, /* apiflags= */ TCP_WRITE_FLAG_COPY) == ERR_OK;
 }
 
-bool TcpConnection::flush() const {
+bool Connection::flush() const {
     if (_is_closing) {
         PLOGD("Accessing closed connection.");
         return false;

--- a/src/tcp_connection.cpp
+++ b/src/tcp_connection.cpp
@@ -37,7 +37,7 @@ bool Connection::write(const void* data, uint16_t size) const {
         return true;
     }
 
-    return tcp_write(_pcb, data, size, /* apiflags= */ TCP_WRITE_FLAG_COPY) == ERR_OK;
+    return tcp_write(&_pcb, data, size, /* apiflags= */ TCP_WRITE_FLAG_COPY) == ERR_OK;
 }
 
 bool Connection::flush() const {
@@ -46,7 +46,7 @@ bool Connection::flush() const {
         return false;
     }
 
-    return tcp_output(_pcb) == ERR_OK;
+    return tcp_output(&_pcb) == ERR_OK;
 }
 
 } // namespace tcp

--- a/src/tcp_connection.cpp
+++ b/src/tcp_connection.cpp
@@ -5,7 +5,9 @@
 #include "log.h"
 #include "tcp_server.h"
 
-namespace __http_internal {
+namespace http {
+
+namespace __internal {
 
 bool TcpConnection::sink(pbuf* pbuf) {
     uint8_t* data = new uint8_t[pbuf->tot_len];
@@ -49,4 +51,6 @@ bool TcpConnection::flush() const {
     return tcp_output(_pcb) == ERR_OK;
 }
 
-} // namespace __http_internal
+} // namespace __internal
+
+} // namespace http

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -206,7 +206,7 @@ err_t on_accept_connection(void* argument,
         return ERR_ABRT;
     }
 
-    auto* server = static_cast<tcp::TcpServer*>(argument);
+    auto* server = static_cast<tcp::Server*>(argument);
     auto* connection = server->createConnection(new_pcb);
 
     if (!connection) {
@@ -231,7 +231,7 @@ err_t on_accept_connection(void* argument,
 
 namespace tcp {
 
-bool TcpServer::listen(uint16_t port) {
+bool Server::listen(uint16_t port) {
     bool is_listening = _listen_pcb != nullptr;
     if (is_listening) {
         return false;
@@ -250,7 +250,7 @@ bool TcpServer::listen(uint16_t port) {
     return _listen_pcb != nullptr;
 }
 
-bool TcpServer::write(uint32_t connection_id, const void* data, uint16_t size) const {
+bool Server::write(uint32_t connection_id, const void* data, uint16_t size) const {
     auto* connection = findConnectionById(connection_id);
     if (connection->write(data, size)) {
         return connection->flush();
@@ -259,12 +259,12 @@ bool TcpServer::write(uint32_t connection_id, const void* data, uint16_t size) c
     }
 }
 
-void TcpServer::close(uint32_t connection_id) const {
+void Server::close(uint32_t connection_id) const {
     auto* connection = findConnectionById(connection_id);
     connection->close();
 }
 
-TcpConnection* TcpServer::createConnection(tcp_pcb* pcb) {
+TcpConnection* Server::createConnection(tcp_pcb* pcb) {
     if (_connections.size() >= _max_connections) {
         PLOGD("Connection was aborted, as the amount of open connections is at its limit.");
         return nullptr;
@@ -280,7 +280,7 @@ TcpConnection* TcpServer::createConnection(tcp_pcb* pcb) {
     return connection_ptr;
 }
 
-void TcpServer::onConnected(TcpConnection* connection) {
+void Server::onConnected(TcpConnection* connection) {
     if (!connection) {
         PLOGD("Connected empty connection?!");
         return;
@@ -291,7 +291,7 @@ void TcpServer::onConnected(TcpConnection* connection) {
     }
 }
 
-bool TcpServer::onDataReceived(TcpConnection* connection, uint8_t* data, uint16_t size) {
+bool Server::onDataReceived(TcpConnection* connection, uint8_t* data, uint16_t size) {
     if (_onDataReceivedCallback == nullptr) {
         return false;
     }
@@ -304,7 +304,7 @@ bool TcpServer::onDataReceived(TcpConnection* connection, uint8_t* data, uint16_
     return _onDataReceivedCallback(connection->id(), data, size);
 }
 
-void TcpServer::onConnectionClosed(TcpConnection* connection) {
+void Server::onConnectionClosed(TcpConnection* connection) {
     if (!connection) {
         PLOGD("Trying to close empty connection.");
         return;

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -44,7 +44,7 @@ err_t on_receive_data(void* argument,
                       pbuf* pbuf,
                       err_t err) {
     cyw43_arch_lwip_check();
-    auto* connection = static_cast<tcp::TcpConnection*>(argument);
+    auto* connection = static_cast<tcp::Connection*>(argument);
 
     if (!connection) {
         PLOGD("No connection found on receiving data.");
@@ -91,7 +91,7 @@ err_t on_poll(void* argument,
               tcp_pcb* pcb) {
     cyw43_arch_lwip_check();
 
-    auto* connection = static_cast<tcp::TcpConnection*>(argument);
+    auto* connection = static_cast<tcp::Connection*>(argument);
 
     if (!connection) {
         PLOGD("Argument was null");
@@ -131,7 +131,7 @@ err_t on_sent(void* argument,
              u16_t len) {
     cyw43_arch_lwip_check();
 
-    auto* connection = static_cast<tcp::TcpConnection*>(argument);
+    auto* connection = static_cast<tcp::Connection*>(argument);
 
     if (!connection) {
         PLOGD("Argument was null");
@@ -174,7 +174,7 @@ void on_error(void* argument,
         PLOGD("TCP Connection failed with %d\n", error);
     }
 
-    auto* connection = static_cast<tcp::TcpConnection*>(argument);
+    auto* connection = static_cast<tcp::Connection*>(argument);
     if (connection) {
         PLOGD("Marking connection as closed, from on_error.");
         connection->close();
@@ -264,13 +264,13 @@ void Server::close(uint32_t connection_id) const {
     connection->close();
 }
 
-TcpConnection* Server::createConnection(tcp_pcb* pcb) {
+Connection* Server::createConnection(tcp_pcb* pcb) {
     if (_connections.size() >= _max_connections) {
         PLOGD("Connection was aborted, as the amount of open connections is at its limit.");
         return nullptr;
     }
 
-    auto connection = std::make_unique<TcpConnection>(*this, pcb);
+    auto connection = std::make_unique<Connection>(*this, pcb);
     auto* connection_ptr = connection.get();
     uint32_t connection_id = connection->id();
 
@@ -280,7 +280,7 @@ TcpConnection* Server::createConnection(tcp_pcb* pcb) {
     return connection_ptr;
 }
 
-void Server::onConnected(TcpConnection* connection) {
+void Server::onConnected(Connection* connection) {
     if (!connection) {
         PLOGD("Connected empty connection?!");
         return;
@@ -291,7 +291,7 @@ void Server::onConnected(TcpConnection* connection) {
     }
 }
 
-bool Server::onDataReceived(TcpConnection* connection, uint8_t* data, uint16_t size) {
+bool Server::onDataReceived(Connection* connection, uint8_t* data, uint16_t size) {
     if (_onDataReceivedCallback == nullptr) {
         return false;
     }
@@ -304,7 +304,7 @@ bool Server::onDataReceived(TcpConnection* connection, uint8_t* data, uint16_t s
     return _onDataReceivedCallback(connection->id(), data, size);
 }
 
-void Server::onConnectionClosed(TcpConnection* connection) {
+void Server::onConnectionClosed(Connection* connection) {
     if (!connection) {
         PLOGD("Trying to close empty connection.");
         return;

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -270,7 +270,7 @@ Connection* Server::createConnection(tcp_pcb* pcb) {
         return nullptr;
     }
 
-    auto connection = std::make_unique<Connection>(*this, pcb);
+    auto connection = std::make_unique<Connection>(*this, *pcb);
     auto* connection_ptr = connection.get();
     uint32_t connection_id = connection->id();
 
@@ -280,7 +280,7 @@ Connection* Server::createConnection(tcp_pcb* pcb) {
     return connection_ptr;
 }
 
-void Server::onConnected(Connection* connection) {
+void Server::onConnected(Connection* connection) const {
     if (!connection) {
         PLOGD("Connected empty connection?!");
         return;
@@ -291,7 +291,7 @@ void Server::onConnected(Connection* connection) {
     }
 }
 
-bool Server::onDataReceived(Connection* connection, uint8_t* data, uint16_t size) {
+bool Server::onDataReceived(Connection* connection, uint8_t* data, uint16_t size) const {
     if (_onDataReceivedCallback == nullptr) {
         return false;
     }
@@ -316,6 +316,20 @@ void Server::onConnectionClosed(Connection* connection) {
     if (_onClosedCallback) {
         _onClosedCallback(connection_id);
     }
+}
+
+bool Server::stop() {
+    if (_listen_pcb != nullptr) {
+        tcp_close(_listen_pcb);
+        _listen_pcb = nullptr;
+        return true;
+    }
+
+    return false;
+}
+
+Server::~Server() {
+    stop();
 }
 
 } // namespace tcp

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -44,7 +44,7 @@ err_t on_receive_data(void* argument,
                       pbuf* pbuf,
                       err_t err) {
     cyw43_arch_lwip_check();
-    auto* connection = static_cast<__http_internal::TcpConnection*>(argument);
+    auto* connection = static_cast<http::__internal::TcpConnection*>(argument);
 
     if (!connection) {
         PLOGD("No connection found on receiving data.");
@@ -91,7 +91,7 @@ err_t on_poll(void* argument,
               tcp_pcb* pcb) {
     cyw43_arch_lwip_check();
 
-    auto* connection = static_cast<__http_internal::TcpConnection*>(argument);
+    auto* connection = static_cast<http::__internal::TcpConnection*>(argument);
 
     if (!connection) {
         PLOGD("Argument was null");
@@ -131,7 +131,7 @@ err_t on_sent(void* argument,
              u16_t len) {
     cyw43_arch_lwip_check();
 
-    auto* connection = static_cast<__http_internal::TcpConnection*>(argument);
+    auto* connection = static_cast<http::__internal::TcpConnection*>(argument);
 
     if (!connection) {
         PLOGD("Argument was null");
@@ -174,7 +174,7 @@ void on_error(void* argument,
         PLOGD("TCP Connection failed with %d\n", error);
     }
 
-    auto* connection = static_cast<__http_internal::TcpConnection*>(argument);
+    auto* connection = static_cast<http::__internal::TcpConnection*>(argument);
     if (connection) {
         PLOGD("Marking connection as closed, from on_error.");
         connection->close();
@@ -206,7 +206,7 @@ err_t on_accept_connection(void* argument,
         return ERR_ABRT;
     }
 
-    auto* server = static_cast<__http_internal::TcpServer*>(argument);
+    auto* server = static_cast<http::__internal::TcpServer*>(argument);
     auto* connection = server->createConnection(new_pcb);
 
     if (!connection) {
@@ -229,7 +229,9 @@ err_t on_accept_connection(void* argument,
 
 } // namespace
 
-namespace __http_internal {
+namespace http {
+
+namespace __internal {
 
 bool TcpServer::listen(uint16_t port) {
     bool is_listening = _listen_pcb != nullptr;
@@ -318,4 +320,6 @@ void TcpServer::onConnectionClosed(TcpConnection* connection) {
     }
 }
 
-} // _http_internal
+} // namespace __internal
+
+} // namespace http

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -44,7 +44,7 @@ err_t on_receive_data(void* argument,
                       pbuf* pbuf,
                       err_t err) {
     cyw43_arch_lwip_check();
-    auto* connection = static_cast<http::__internal::TcpConnection*>(argument);
+    auto* connection = static_cast<tcp::TcpConnection*>(argument);
 
     if (!connection) {
         PLOGD("No connection found on receiving data.");
@@ -91,7 +91,7 @@ err_t on_poll(void* argument,
               tcp_pcb* pcb) {
     cyw43_arch_lwip_check();
 
-    auto* connection = static_cast<http::__internal::TcpConnection*>(argument);
+    auto* connection = static_cast<tcp::TcpConnection*>(argument);
 
     if (!connection) {
         PLOGD("Argument was null");
@@ -131,7 +131,7 @@ err_t on_sent(void* argument,
              u16_t len) {
     cyw43_arch_lwip_check();
 
-    auto* connection = static_cast<http::__internal::TcpConnection*>(argument);
+    auto* connection = static_cast<tcp::TcpConnection*>(argument);
 
     if (!connection) {
         PLOGD("Argument was null");
@@ -174,7 +174,7 @@ void on_error(void* argument,
         PLOGD("TCP Connection failed with %d\n", error);
     }
 
-    auto* connection = static_cast<http::__internal::TcpConnection*>(argument);
+    auto* connection = static_cast<tcp::TcpConnection*>(argument);
     if (connection) {
         PLOGD("Marking connection as closed, from on_error.");
         connection->close();
@@ -206,7 +206,7 @@ err_t on_accept_connection(void* argument,
         return ERR_ABRT;
     }
 
-    auto* server = static_cast<http::__internal::TcpServer*>(argument);
+    auto* server = static_cast<tcp::TcpServer*>(argument);
     auto* connection = server->createConnection(new_pcb);
 
     if (!connection) {
@@ -229,9 +229,7 @@ err_t on_accept_connection(void* argument,
 
 } // namespace
 
-namespace http {
-
-namespace __internal {
+namespace tcp {
 
 bool TcpServer::listen(uint16_t port) {
     bool is_listening = _listen_pcb != nullptr;
@@ -320,6 +318,4 @@ void TcpServer::onConnectionClosed(TcpConnection* connection) {
     }
 }
 
-} // namespace __internal
-
-} // namespace http
+} // namespace tcp


### PR DESCRIPTION
- Renaming `internal` namespaces
- Removing `Http` prefix
- Creating `tcp` namespace
- Defining additional `enum` values, according to mdn definitions
- Defining `copy`/`move` semantic for classes
- Adding references
- Adding `RTO`s